### PR TITLE
Replace sudo command with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,10 @@
   apt_repository: repo='ppa:nginx/stable' state=present
   
 - name: Install Nginx
-  sudo: yes
+  become: yes
   apt: pkg=nginx state=latest update_cache=true
 
 - name: Change default nginx site
-  sudo: yes
+  become: yes
   template: src=default.tpl dest=/etc/nginx/sites-available/default
   notify: restart nginx


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)
Replace `sudo` command `become`since `sudo` will be deprecated.
